### PR TITLE
[feat] #15 : 상단 navbar 및 라우팅 구현

### DIFF
--- a/shared/ui/NavItem.tsx
+++ b/shared/ui/NavItem.tsx
@@ -1,0 +1,24 @@
+import { Link, useLocation } from "react-router-dom";
+
+interface NavItemProps {
+  path: string;
+  label: string;
+}
+
+function NavItem({ path, label }: NavItemProps) {
+  const location = useLocation();
+  const isActive = location.pathname === path; // 현재 경로 확인
+
+  return (
+    <Link
+      to={path}
+      className={`pb-2 border-b-3 text-gray-800 hover:underline ${
+        isActive ? "border-gray-800 font-bold" : "border-transparent"
+      }`}
+    >
+      {label}
+    </Link>
+  );
+}
+
+export default NavItem;

--- a/shared/ui/Navbar.tsx
+++ b/shared/ui/Navbar.tsx
@@ -1,0 +1,17 @@
+import NavItem from "./NavItem";
+
+interface NavbarProps {
+  items: { path: string; label: string }[];
+}
+
+function Navbar({ items }: NavbarProps) {
+  return (
+    <nav className="flex space-x-4">
+      {items.map((item) => (
+        <NavItem key={item.path} path={item.path} label={item.label} />
+      ))}
+    </nav>
+  );
+}
+
+export default Navbar;

--- a/src/app/providers/RoleBasedRedirect.tsx
+++ b/src/app/providers/RoleBasedRedirect.tsx
@@ -5,7 +5,7 @@ const userRole : string = "manager"; //context에서 불러오는 값
 
 function RoleBasedRedirect() {
   if (userRole === "member") return <Navigate to="/userpage" replace />;
-  if (userRole === "manager") return <Navigate to="/adminpage/mytask" replace />;
+  if (userRole === "manager") return <Navigate to="/adminpage/workview" replace />;
   return <Navigate to="/login" replace />;
 };
 

--- a/src/app/routes/routes.tsx
+++ b/src/app/routes/routes.tsx
@@ -2,12 +2,13 @@ import { createBrowserRouter, Outlet } from "react-router-dom";
 import LoginPage from "@/pages/LoginPage";
 import MainPage from "@/pages/MainPage";
 import UserPage from "@/pages/UserPage";
-import MyTaskPage from "@/pages/admin/MyTaskPage";
-import WorkViewPage from "@/pages/admin/WorkViewPage";
 import AddUserPage from "@/pages/admin/AddUserPage";
 import ProtectedRoute from "../providers/ProtectedRoute";
 import RoleBasedRedirect from "../providers/RoleBasedRedirect";
 import Layout from "../layouts/Layout";
+import WorkViewPage from "@/pages/admin/WorkViewPage";
+import SearchFilePage from "@/pages/SearchFilePage";
+
 
 const router = createBrowserRouter([
   {
@@ -26,6 +27,10 @@ const router = createBrowserRouter([
             element: <MainPage />,
           },
           {
+            path: "searchfile",
+            element: <SearchFilePage />,
+          },
+          {
             path: "mypage",
             element: <RoleBasedRedirect />
           },
@@ -37,7 +42,6 @@ const router = createBrowserRouter([
             path: "adminpage",
             element: <Outlet />, 
             children: [
-              { path: "mytask", element: <MyTaskPage /> },
               { path: "workview", element: <WorkViewPage /> },
               { path: "adduser", element: <AddUserPage />},
             ]

--- a/src/pages/SearchFilePage.tsx
+++ b/src/pages/SearchFilePage.tsx
@@ -1,18 +1,16 @@
-import { DataTable } from "../../shared/ui/DataTable";
 import Navbar from "../../shared/ui/Navbar";
 
-function MainPage() {
+function SearchFilePage() {
   const navItems = [
     { path: "/", label: "파일 업로드" },
     { path: "/searchfile", label: "파일 조회"},
   ]
-
   return (
     <div>
-      <Navbar items={navItems}/>
-      <DataTable></DataTable>
+      <Navbar items={navItems} />
+      SearchFilePage
     </div>
   );
 }
 
-export default MainPage;
+export default SearchFilePage;

--- a/src/pages/admin/AddUserPage.tsx
+++ b/src/pages/admin/AddUserPage.tsx
@@ -1,5 +1,16 @@
+import Navbar from "../../../shared/ui/Navbar";
+
 function AddUserPage() {
-  return <div>AddUserPage</div>
+  const navItems = [
+    { path: "/adminpage/workview", label: "업무 조회" },
+    { path: "/adminpage/adduser", label: "사용자 등록" },
+  ]
+  return (
+    <div>
+      <Navbar items={navItems}/>
+      adduser page
+    </div>
+  )
 }
 
 export default AddUserPage;

--- a/src/pages/admin/MyTaskPage.tsx
+++ b/src/pages/admin/MyTaskPage.tsx
@@ -1,5 +1,0 @@
-function MyTaskPage() {
-  return <div>MyTaskPage</div>
-}
-
-export default MyTaskPage;

--- a/src/pages/admin/WorkViewPage.tsx
+++ b/src/pages/admin/WorkViewPage.tsx
@@ -1,5 +1,16 @@
+import Navbar from "../../../shared/ui/Navbar";
+
 function WorkViewPage() {
-  return <div>WorkViewPage</div>
+  const navItems = [
+    { path: "/adminpage/workview", label: "업무 조회" },
+    { path: "/adminpage/adduser", label: "사용자 등록" },
+  ]
+  return (
+    <div>
+      <Navbar items={navItems}/>
+      WorkViewPage
+    </div>
+  )
 }
 
 export default WorkViewPage;


### PR DESCRIPTION
# 🛠 구현 사항
Close #15 
- 메인 홈, 내 업무 관리 페이지에 재사용 가능한 navbar구현
- 버튼에 표시될 text와 path를 props로 넘겨서 이동하도록 구현했습니다.
- 메인(파일 업로드-"/", 파일 조회-"/searchfile"), 내 업무 관리(업무 조회-"adminpage/workview", 사용자 등록-"adminpage/adduser") 라우팅

# ❓ 질문

- 질문 작성

# 📸 화면 캡처
<img width="1229" alt="스크린샷 2025-02-25 오전 2 11 57" src="https://github.com/user-attachments/assets/035a4b62-f184-45cd-91d9-8b42e296a352" />
